### PR TITLE
add UTC/GMT support to reverse Etc/GMT timezone offset 

### DIFF
--- a/src/Timezone.ts
+++ b/src/Timezone.ts
@@ -31,7 +31,7 @@ export class Timezone {
   private get localization (): TimezoneLocalizedData {
     const localeId = getActiveLocale()
     if (!(localeId in this.localizations)) {
-      const group = this.territoryId === '' ? '' : translateTerritory(this.territoryId, localeId)
+      const group = this.territoryId === '' ? 'others' : translateTerritory(this.territoryId, localeId)
       const locality = translateExemplarCity(this.exemplarCityId, localeId)
       if (!locality) {
         translateExemplarCity(this.exemplarCityId, localeId)
@@ -58,7 +58,18 @@ export class Timezone {
 const map : { [id: string] : Timezone} = {}
 
 const all: Timezone[] = []
-
+function addUtcTimeZones() {
+  // Moment.js uses the IANA timezone database, which supports generic time zones like 'Etc/GMT+1'.
+  // However, the signs for these time zones are inverted compared to ISO 8601.
+  // For more details, see https://github.com/moment/moment-timezone/issues/167
+  for (let offset = -12; offset <= 12; offset++) {
+    const posixSign = offset <= 0 ? '+' : '-';
+    const isoSign = offset >= 0 ? '+' : '-';
+    const link = `Etc/GMT${posixSign}${Math.abs(offset)}|UTC/GMT${isoSign}${Math.abs(offset)}`;
+    moment.tz.link(link);
+  }
+}
+addUtcTimeZones()
 const ids: string[] = moment.tz.names()
 ids.forEach((id) => {
   const timezone = new Timezone(id)

--- a/src/components/Configurer.vue
+++ b/src/components/Configurer.vue
@@ -136,7 +136,7 @@ export default class Configurer extends Vue {
       }
     })
     if (hasOthers) {
-      result.push({ value: '', text: this.NO_GROUP_TEXT })
+      result.push({ value: 'others', text: this.NO_GROUP_TEXT })
     }
     return result
   }


### PR DESCRIPTION
Because the existing Etc/GMT offset is reverse as useral GMT[+-] offset, so I added UTC/GMT groups in the Configure and timezone pickup.

And meanwhile fix a but about "others" group related timezone missing issue.